### PR TITLE
Suppress highlighting inside strings for modes which have them

### DIFF
--- a/outline-minor-faces.el
+++ b/outline-minor-faces.el
@@ -117,14 +117,14 @@ string."
       (and (re-search-forward regexp limit t)
            (not (nth 8 (syntax-ppss)))))))
 
-(defun outline-minor-faces--font-lock-keywords ()
-  `((eval . (list ,(outline-minor-faces--syntactic-matcher
-                    (or outline-minor-faces-regexp
-                        (concat "^\\(?:"
-                                (if (derived-mode-p 'lisp-mode 'emacs-lisp-mode)
-                                    ";;;\\(;* [^ \t\n]\\)"
-                                  outline-regexp)
-                                "\\)\\(?:.+\n\\|\n?\\)")))
+(defvar outline-minor-faces--font-lock-keywords
+  '((eval . (list (outline-minor-faces--syntactic-matcher
+                   (or outline-minor-faces-regexp
+                       (concat "^\\(?:"
+                               (if (derived-mode-p 'lisp-mode 'emacs-lisp-mode)
+                                   ";;;\\(;* [^ \t\n]\\)"
+                                 outline-regexp)
+                               "\\)\\(?:.+\n\\|\n?\\)")))
                   0 '(outline-minor-faces--get-face) t))))
 
 (defvar-local outline-minor-faces--top-level nil)
@@ -152,7 +152,7 @@ string."
 ;;;###autoload
 (defun outline-minor-faces-add-font-lock-keywords ()
   (ignore-errors
-    (font-lock-add-keywords nil (outline-minor-faces--font-lock-keywords) t)
+    (font-lock-add-keywords nil outline-minor-faces--font-lock-keywords t)
     (save-restriction
       (widen)
       (font-lock-flush)

--- a/outline-minor-faces.el
+++ b/outline-minor-faces.el
@@ -104,13 +104,27 @@ If this is nil, then a regular expression based on
 be used directly because it is only supposed to match the
 beginning of a heading.")
 
+(defun outline-minor-faces--syntactic-matcher (regexp)
+  "Return a matcher that matches REGEXP only outside of strings.
+
+Returns REGEXP directly for modes where `font-lock-keywords-only'
+is non-nil because Font Lock does not mark strings and comments
+for those modes, and the matcher will not know what is/is not a
+string."
+  (if font-lock-keywords-only
+      regexp
+    (lambda (limit)
+      (and (re-search-forward regexp limit t)
+           (not (nth 8 (syntax-ppss)))))))
+
 (defun outline-minor-faces--font-lock-keywords ()
-  `((eval . (list ,(or outline-minor-faces-regexp
-                       (concat "^\\(?:"
-                               (if (derived-mode-p 'lisp-mode 'emacs-lisp-mode)
-                                   ";;;\\(;* [^ \t\n]\\)"
-                                 outline-regexp)
-                               "\\)\\(?:.+\n\\|\n?\\)"))
+  `((eval . (list ,(outline-minor-faces--syntactic-matcher
+                    (or outline-minor-faces-regexp
+                        (concat "^\\(?:"
+                                (if (derived-mode-p 'lisp-mode 'emacs-lisp-mode)
+                                    ";;;\\(;* [^ \t\n]\\)"
+                                  outline-regexp)
+                                "\\)\\(?:.+\n\\|\n?\\)")))
                   0 '(outline-minor-faces--get-face) t))))
 
 (defvar-local outline-minor-faces--top-level nil)


### PR DESCRIPTION
Thanks for writing this.

This PR makes it so strings like `"asdf ;;; jkl"` are not highlighted--only comments are. Previously, text inside strings in programming modes that matched `outline-minor-faces-regexp` were highlighted to the end of the line if your regexp was not anchored to beginning-of-line. For example, my regexp is `";;;+[^#].*$"` so indented comments can also be headings, but it results in:

![previous](https://user-images.githubusercontent.com/52264243/77851782-76483e80-71ca-11ea-83c8-62d312446f81.png)

This made for some confusing syntax highlighting, and is a problem with the default regexp for multiline strings.

Now, everything that used to be highlighted still is, except for matches inside strings.

The way it works is that if `font-lock-keywords-only` is `nil` (true for modes that have strings and comments), a function is used as the matcher which checks if the matched text has already been fontified as a string, and returns `nil` if so. If keyword-only matching is on (true for text modes, etc.) then the regexp is used directly and there is no performance hit.

I've also changed `outline-minor-faces--font-lock-keywords` to a static variable rather than a function, since according to the [manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Search_002dbased-Fontification.html#Search_002dbased-Fontification), Font Lock keywords with `eval` are evaluated only _once_ in a buffer so the effect is the same as running a function to get the matcher while being simpler.
