### PR TITLE
Make comments outside strings still be highlighted

### DIFF
--- a/outline-minor-faces.el
+++ b/outline-minor-faces.el
@@ -115,7 +115,7 @@ string."
       regexp
     (lambda (limit)
       (and (re-search-forward regexp limit t)
-           (not (nth 8 (syntax-ppss)))))))
+           (not (nth 3 (syntax-ppss (match-beginning 0))))))))
 
 (defvar outline-minor-faces--font-lock-keywords
   '((eval . (list (outline-minor-faces--syntactic-matcher


### PR DESCRIPTION
Hi again :)

The `syntax-ppss` solution in c48bae7 broke my config since the 8th slot of `syntax-ppss` is "character address of start of comment **or** string; nil if not in one" according to the manual, so comments were also not being highlighted. All the headings in my source files are comments, so basically nothing got highlighted.

I have tweaked `outline-minor-faces--syntactic-matcher` slightly, still using `syntax-ppss`, but checking the 3rd slot of the result which is "non-nil if inside a string." It also now checks if the start of the match is in a string, since even the default `outline-minor-faces-regexp` for Elisp matches to the end of the line, so point will be at the end of the line where single-line strings have already ended.

I have tested that this code _does_ match all wanted headings, does _not_ match in single-line strings, does _not_ match in multiline strings, and does _not_ match in docstrings.

Thanks!