### PR TITLE
Add outline-minor-faces-remove-font-lock-keywords

### DIFF
--- a/outline-minor-faces.el
+++ b/outline-minor-faces.el
@@ -159,10 +159,18 @@ string."
 (defun outline-minor-faces-add-font-lock-keywords ()
   (ignore-errors
     (font-lock-add-keywords nil outline-minor-faces--font-lock-keywords t)
-    (save-restriction
+    (outline-minor-faces--apply-font-lock-keywords)))
+
+(defun outline-minor-faces-remove-font-lock-keywords ()
+  (ignore-errors
+    (font-lock-remove-keywords nil outline-minor-faces--font-lock-keywords)
+    (outline-minor-faces--apply-font-lock-keywords)))
+
+(defun outline-minor-faces--apply-font-lock-keywords ()
+  (save-restriction
       (widen)
       (font-lock-flush)
-      (font-lock-ensure))))
+      (font-lock-ensure)))
 
 (defun outline-minor-faces--get-face ()
   (save-excursion


### PR DESCRIPTION
The new function allow us to revert the added keywords by `outline-minor-faces-add-font-lock-keywords` (like turning off a minor mode). It may be used as a quick way to test if this package is getting in the way of something.

If creating a new function is not ideal, can we add an argument to `outline-minor-faces-add-font-lock-keywords` instead?

```lisp
;;;###autoload
(defun outline-minor-faces-add-font-lock-keywords (&optional remove)
  (ignore-errors
    (if remove
        (font-lock-remove-keywords nil outline-minor-faces--font-lock-keywords)
      (font-lock-add-keywords nil outline-minor-faces--font-lock-keywords t))
    (save-restriction
      (widen)
      (font-lock-flush)
      (font-lock-ensure))))
```

